### PR TITLE
[Feature] WIP - Load PDFs internally or externally

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.READ_SYNC_STATS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <supports-screens
         android:largeScreens="true"

--- a/app/src/main/java/com/github/mobile/ui/DialogFragmentHelper.java
+++ b/app/src/main/java/com/github/mobile/ui/DialogFragmentHelper.java
@@ -111,7 +111,7 @@ public abstract class DialogFragmentHelper extends RoboDialogFragment implements
     /**
      * Get message
      *
-     * @return mesage
+     * @return message
      */
     protected String getMessage() {
         return getArguments().getString(ARG_MESSAGE);

--- a/app/src/main/java/com/github/mobile/ui/commit/CommitFileViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/commit/CommitFileViewActivity.java
@@ -149,7 +149,8 @@ public class CommitFileViewActivity extends BaseActivity {
             wrapItem.setEnabled(false);
             wrapItem.setVisible(false);
         } else {
-            if (PreferenceUtils.getCodePreferences(this).getBoolean(WRAP, false))
+            if (PreferenceUtils.getCodePreferences(this)
+                    .getBoolean(WRAP, false))
                 wrapItem.setTitle(string.disable_wrapping);
             else
                 wrapItem.setTitle(string.enable_wrapping);

--- a/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/ref/BranchFileViewActivity.java
@@ -84,8 +84,20 @@ public class BranchFileViewActivity extends BaseActivity implements
         return false;
     }
 
+    private static final String URL_GOOGLEDOCS = "https://docs.google.com/gview?embedded=true&url=";
+
+    private static boolean isPDF(final String name) {
+        if (TextUtils.isEmpty(name))
+            return false;
+
+        if (name.endsWith(".pdf"))
+            return true;
+
+        return false;
+    }
+
     /**
-     * Create intent to show file in commit
+     * Create intent to show file in branch
      *
      * @param repository
      * @param branch
@@ -114,6 +126,8 @@ public class BranchFileViewActivity extends BaseActivity implements
     private String branch;
 
     private boolean isMarkdownFile;
+
+    private boolean isPDFFile;
 
     private String renderedMarkdown;
 
@@ -149,6 +163,8 @@ public class BranchFileViewActivity extends BaseActivity implements
 
         file = CommitUtils.getName(path);
         isMarkdownFile = isMarkdown(file);
+        isPDFFile = isPDF(file);
+
         editor = new SourceEditor(codeView);
         editor.setWrap(PreferenceUtils.getCodePreferences(this).getBoolean(
                 WRAP, false));
@@ -166,10 +182,15 @@ public class BranchFileViewActivity extends BaseActivity implements
         getSupportMenuInflater().inflate(menu.file_view, optionsMenu);
 
         MenuItem wrapItem = optionsMenu.findItem(id.m_wrap);
-        if (PreferenceUtils.getCodePreferences(this).getBoolean(WRAP, false))
-            wrapItem.setTitle(string.disable_wrapping);
-        else
-            wrapItem.setTitle(string.enable_wrapping);
+        if (isPDFFile) {
+            wrapItem.setEnabled(false);
+            wrapItem.setVisible(false);
+        } else {
+            if (PreferenceUtils.getCodePreferences(this).getBoolean(WRAP, false))
+                wrapItem.setTitle(string.disable_wrapping);
+            else
+                wrapItem.setTitle(string.enable_wrapping);
+        }
 
         markdownItem = optionsMenu.findItem(id.m_render_markdown);
         if (isMarkdownFile) {
@@ -271,6 +292,16 @@ public class BranchFileViewActivity extends BaseActivity implements
         getSupportLoaderManager().restartLoader(0, args, this);
     }
 
+    private void loadPDF() {
+        ViewUtils.setGone(loadingBar, true);
+        ViewUtils.setGone(codeView, false);
+
+        String id = repo.generateId();
+        String PDFUrl = "https://github.com/" + id + "/blob/" + branch + '/'
+                + path + "?raw=true";
+        codeView.loadUrl(URL_GOOGLEDOCS + PDFUrl);
+    }
+
     private void loadContent() {
         ViewUtils.setGone(loadingBar, false);
         ViewUtils.setGone(codeView, true);
@@ -290,10 +321,11 @@ public class BranchFileViewActivity extends BaseActivity implements
                                 BranchFileViewActivity.this).getBoolean(
                                 RENDER_MARKDOWN, true))
                     loadMarkdown();
+                else if (isPDFFile)
+                    loadPDF();
                 else {
                     ViewUtils.setGone(loadingBar, true);
                     ViewUtils.setGone(codeView, false);
-
                     editor.setMarkdown(false).setSource(file, blob);
                 }
             }

--- a/app/src/main/java/com/github/mobile/util/GingerbreadFileGetter.java
+++ b/app/src/main/java/com/github/mobile/util/GingerbreadFileGetter.java
@@ -1,0 +1,125 @@
+package com.github.mobile.util;
+
+import static android.app.DownloadManager.ACTION_DOWNLOAD_COMPLETE;
+import static android.app.DownloadManager.COLUMN_STATUS;
+import static android.app.DownloadManager.STATUS_SUCCESSFUL;
+import static android.content.Context.DOWNLOAD_SERVICE;
+import static android.os.Environment.DIRECTORY_DOWNLOADS;
+
+import java.io.File;
+
+import android.annotation.TargetApi;
+import android.app.DownloadManager;
+import android.app.DownloadManager.Query;
+import android.app.DownloadManager.Request;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+
+import com.github.mobile.core.commit.CommitUtils;
+
+/**
+ * Getter for a file
+ */
+@TargetApi(Build.VERSION_CODES.GINGERBREAD)
+public class GingerbreadFileGetter {
+
+    private Context context;
+
+    private String source;
+
+    private File destination;
+
+    private DownloadManager dm;
+
+    private BroadcastReceiver receiver;
+
+    private long downloadId;
+
+    public interface OnDownloadCompleteListener {
+        public abstract void onDownloadCompleted(boolean result, File file);
+    }
+
+    OnDownloadCompleteListener onDownloadCompleteListener;
+
+    /**
+     * Create file getter for context
+     *
+     * @param context
+     * @param source
+     */
+    public GingerbreadFileGetter(Context context, String source) {
+        this.context = context;
+        this.source = source;
+        this.destination = new File(
+                Environment
+                        .getExternalStoragePublicDirectory(DIRECTORY_DOWNLOADS),
+                CommitUtils.getName(source));
+        this.dm = (DownloadManager) context.getSystemService(DOWNLOAD_SERVICE);
+        this.receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                GingerbreadFileGetter.this.onReceive(context, intent);
+            }
+        };
+        registerDownloadReceiver();
+    }
+
+    public void beginDownload() {
+        Request request = new Request(Uri.parse(source));
+        request.setDestinationUri(Uri.fromFile(destination));
+        request.setVisibleInDownloadsUi(true);
+
+        downloadId = dm.enqueue(request);
+    }
+
+    public void cancelDownload() {
+        dm.remove(downloadId);
+        unregisterDownloadReceiver();
+    }
+
+    public void setDownloadCompleteListener(OnDownloadCompleteListener listener) {
+        onDownloadCompleteListener = listener;
+    }
+
+    private void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        if (!ACTION_DOWNLOAD_COMPLETE.equals(action))
+            return;
+
+        Query query = new Query();
+        query.setFilterById(downloadId);
+
+        Cursor c = dm.query(query);
+        if (!c.moveToFirst())
+            return;
+
+        int colStatus = c.getColumnIndex(COLUMN_STATUS);
+        if (STATUS_SUCCESSFUL == c.getInt(colStatus)) {
+            if (destination.exists())
+                onDownloadCompleteListener.onDownloadCompleted(true,
+                        destination);
+            else
+                onDownloadCompleteListener.onDownloadCompleted(false, null);
+        } else {
+            onDownloadCompleteListener.onDownloadCompleted(false, null);
+        }
+
+        unregisterDownloadReceiver();
+    }
+
+    private void registerDownloadReceiver() {
+        context.registerReceiver(receiver, new IntentFilter(
+                ACTION_DOWNLOAD_COMPLETE));
+    }
+
+    private void unregisterDownloadReceiver() {
+        context.unregisterReceiver(receiver);
+    }
+
+}


### PR DESCRIPTION
The user is prompted to download the PDF with the following prompt:

![2013-04-29 15 03 48](https://f.cloud.github.com/assets/1417401/441158/da478292-b110-11e2-8c42-4740894e4d3b.png)

If the user clicks 'Download', the following progress dialog appears and the download progress is shown in the notification drawer.

![2013-04-29 15 04 31](https://f.cloud.github.com/assets/1417401/441159/ec5230c2-b110-11e2-956e-a184510c709f.png)

Finally, the user is prompted to choose which application to use to open the downloaded PDF.

The file is downloaded to the public Download folder if external storage is available. Otherwise, it is loaded using the Google docs viewer. 

If the download fails for some reason, a toast appears, notifying them that the PDF will be loaded internally instead.  This means that the link to the file will be loaded using the Googledocs viewer in the current File View activity.

This has been confirmed to work on a 4.2.2 Galaxy Nexus, a 4.1.2 emulator, and a 2.2 emulator.

### TODO
* Implement a FileGetter (probably using HTTP) for Froyo
