### PR TITLE
Cleaned up a bunch of stuff about gists

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -53,7 +53,7 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
 
-                <data android:mimeType="text/plain" />
+                <data android:mimeType="text/*" />
             </intent-filter>
         </activity>
         <activity

--- a/app/res/values/strings.xml
+++ b/app/res/values/strings.xml
@@ -146,7 +146,9 @@
     <string name="title">Title</string>
     <string name="edit">Edit</string>
     <string name="starring_gist">Starring Gist…</string>
+    <string name="starred_gist">Successfully starred Gist</string>
     <string name="unstarring_gist">Unstarring Gist…</string>
+    <string name="unstarred_gist">Successfully unstarred Gist</string>
     <string name="accounts_label">Accounts</string>
     <string name="select_assignee">Select Assignee</string>
     <string name="select_milestone">Select Milestone</string>

--- a/app/src/main/java/com/github/mobile/ui/PagerActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/PagerActivity.java
@@ -77,6 +77,15 @@ public abstract class PagerActivity extends DialogFragmentActivity implements
     }
 
     @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        SherlockFragment fragment = getFragment();
+        if (fragment != null)
+            fragment.onPrepareOptionsMenu(menu);
+
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
     public void onPageScrolled(int position, float positionOffset,
             int positionOffsetPixels) {
         // Intentionally left blank

--- a/app/src/main/java/com/github/mobile/ui/gist/DeleteGistTask.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/DeleteGistTask.java
@@ -18,6 +18,7 @@ package com.github.mobile.ui.gist;
 import static android.app.Activity.RESULT_OK;
 import android.accounts.Account;
 import android.app.Activity;
+import android.content.Intent;
 import android.util.Log;
 
 import com.github.mobile.R.string;
@@ -34,6 +35,8 @@ import org.eclipse.egit.github.core.service.GistService;
 public class DeleteGistTask extends ProgressDialogTask<Gist> {
 
     private static final String TAG = "DeleteGistTask";
+
+    public static final String EXTRA_DELETED_GIST = "deleted_gist";
 
     private final String id;
 
@@ -74,7 +77,9 @@ public class DeleteGistTask extends ProgressDialogTask<Gist> {
         super.onSuccess(gist);
 
         Activity activity = (Activity) getContext();
-        activity.setResult(RESULT_OK);
+        Intent intent = new Intent();
+        intent.putExtra(EXTRA_DELETED_GIST, id);
+        activity.setResult(RESULT_OK, intent);
         activity.finish();
     }
 

--- a/app/src/main/java/com/github/mobile/ui/gist/DeleteGistTask.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/DeleteGistTask.java
@@ -36,7 +36,7 @@ public class DeleteGistTask extends ProgressDialogTask<Gist> {
 
     private static final String TAG = "DeleteGistTask";
 
-    public static final String EXTRA_DELETED_GIST = "deleted_gist";
+    public static final String EXTRA_DELETED_GIST = "extra_deleted_gist";
 
     private final String id;
 

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFileFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFileFragment.java
@@ -133,7 +133,7 @@ public class GistFileFragment extends DialogFragment implements
             // toggle it's current value
             editor.setWrap(!editor.getWrap());
             PreferenceUtils.save(codePrefs.edit().putBoolean(WRAP,
-                editor.getWrap()));
+                    editor.getWrap()));
             return true;
         default:
             return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFileFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFileFragment.java
@@ -111,27 +111,29 @@ public class GistFileFragment extends DialogFragment implements
         updateWrapItem();
     }
 
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        updateWrapItem();
+    }
+
     private void updateWrapItem() {
-        if (wrapItem != null)
+        if (wrapItem != null) {
             if (codePrefs.getBoolean(WRAP, false))
                 wrapItem.setTitle(string.disable_wrapping);
             else
                 wrapItem.setTitle(string.enable_wrapping);
+        }
     }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
         case id.m_wrap:
-            if (editor.getWrap()) {
-                item.setTitle(string.enable_wrapping);
-                editor.setWrap(false);
-            } else {
-                item.setTitle(string.disable_wrapping);
-                editor.setWrap(true);
-            }
+            // If the user selected the wrapping options, that mean they want
+            // toggle it's current value
+            editor.setWrap(!editor.getWrap());
             PreferenceUtils.save(codePrefs.edit().putBoolean(WRAP,
-                    editor.getWrap()));
+                editor.getWrap()));
             return true;
         default:
             return super.onOptionsItemSelected(item);
@@ -206,7 +208,6 @@ public class GistFileFragment extends DialogFragment implements
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences,
             String key) {
         if (WRAP.equals(key)) {
-            updateWrapItem();
             editor.setWrap(sharedPreferences.getBoolean(WRAP, false));
         }
     }

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
@@ -27,6 +27,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -230,11 +231,10 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
     public void onPrepareOptionsMenu(Menu menu) {
         super.onPrepareOptionsMenu(menu);
 
-        boolean owner = isOwner();
-        if (!owner) {
+        if (!isOwner()) {
             menu.removeItem(id.m_delete);
             MenuItem starItem = menu.findItem(id.m_star);
-            starItem.setEnabled(loadFinished && !owner);
+            starItem.setEnabled(loadFinished);
             if (starred)
                 starItem.setTitle(string.unstar);
             else
@@ -280,6 +280,8 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 super.onSuccess(gist);
 
                 starred = true;
+                // We invalidate the options menu so that "Unstar" is now shown
+                getActivity().invalidateOptionsMenu();
             }
 
             @Override
@@ -313,6 +315,8 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 super.onSuccess(gist);
 
                 starred = false;
+                // We invalidate the options menu so that "Star" is now shown
+                getActivity().invalidateOptionsMenu();
             }
 
             protected void onException(Exception e) throws RuntimeException {
@@ -412,6 +416,9 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 updateList(fullGist.getGist(), fullGist);
 
                 getSherlockActivity().setSupportProgressBarIndeterminateVisibility(false);
+
+                // Update the action bar to reflect the newly acquired information
+                getActivity().invalidateOptionsMenu();
             }
 
         }.execute();

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
@@ -27,7 +27,6 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
@@ -27,6 +27,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -299,7 +300,7 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 super.onSuccess(gist);
 
                 starred = true;
-                starListener.onGistStarred(gist);
+                starListener.onGistStarred(GistFragment.this.gist);
                 ToastUtils.show(getActivity(), getString(string.starred_gist));
                 // We invalidate the options menu so that "Unstar" is now shown
                 getActivity().invalidateOptionsMenu();
@@ -336,7 +337,7 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 super.onSuccess(gist);
 
                 starred = false;
-                starListener.onGistUnstarred(gist);
+                starListener.onGistUnstarred(GistFragment.this.gist);
                 ToastUtils.show(getActivity(), getString(
                     string.unstarred_gist));
                 // We invalidate the options menu so that "Star" is now shown

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
@@ -116,10 +116,30 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
 
     private List<View> fileHeaders = new ArrayList<View>();
 
+    private GistStarListener starListener;
+
+    public interface GistStarListener {
+        public void onGistStarred(Gist gist);
+
+        public void onGistUnstarred(Gist gist);
+    }
+
+    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         gistId = getArguments().getString(EXTRA_GIST_ID);
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        if (activity instanceof GistStarListener)
+            starListener = (GistStarListener) activity;
+        else
+            throw new ClassCastException("You must attach GistsFragment to " +
+                " a GistStarListener");
     }
 
     @Override
@@ -279,6 +299,8 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 super.onSuccess(gist);
 
                 starred = true;
+                starListener.onGistStarred(gist);
+                ToastUtils.show(getActivity(), getString(string.starred_gist));
                 // We invalidate the options menu so that "Unstar" is now shown
                 getActivity().invalidateOptionsMenu();
             }
@@ -314,8 +336,12 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 super.onSuccess(gist);
 
                 starred = false;
+                starListener.onGistUnstarred(gist);
+                ToastUtils.show(getActivity(), getString(
+                    string.unstarred_gist));
                 // We invalidate the options menu so that "Star" is now shown
                 getActivity().invalidateOptionsMenu();
+
             }
 
             protected void onException(Exception e) throws RuntimeException {

--- a/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistFragment.java
@@ -27,7 +27,6 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -302,6 +301,7 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 starred = true;
                 starListener.onGistStarred(GistFragment.this.gist);
                 ToastUtils.show(getActivity(), getString(string.starred_gist));
+
                 // We invalidate the options menu so that "Unstar" is now shown
                 getActivity().invalidateOptionsMenu();
             }
@@ -340,6 +340,7 @@ public class GistFragment extends DialogFragment implements OnItemClickListener 
                 starListener.onGistUnstarred(GistFragment.this.gist);
                 ToastUtils.show(getActivity(), getString(
                     string.unstarred_gist));
+
                 // We invalidate the options menu so that "Star" is now shown
                 getActivity().invalidateOptionsMenu();
 

--- a/app/src/main/java/com/github/mobile/ui/gist/GistsViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistsViewActivity.java
@@ -21,6 +21,7 @@ import static com.github.mobile.Intents.EXTRA_GIST;
 import static com.github.mobile.Intents.EXTRA_GIST_ID;
 import static com.github.mobile.Intents.EXTRA_GIST_IDS;
 import static com.github.mobile.Intents.EXTRA_POSITION;
+import static com.github.mobile.ui.gist.GistFragment.GistStarListener;
 import android.content.Intent;
 import android.os.Bundle;
 
@@ -42,6 +43,7 @@ import com.github.mobile.util.AvatarLoader;
 import com.google.inject.Inject;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.egit.github.core.Gist;
@@ -50,9 +52,16 @@ import org.eclipse.egit.github.core.Gist;
  * Activity to display a collection of Gists in a pager
  */
 public class GistsViewActivity extends PagerActivity implements
-        OnLoadListener<Gist> {
+        OnLoadListener<Gist>, GistStarListener {
+
+    public static final String EXTRA_STARRED_GISTS = "extra_starred_gists";
+    public static final String EXTRA_UNSTARRED_GISTS = "extra_unstarred_gists";
 
     private static final int REQUEST_CONFIRM_DELETE = 1;
+
+    private ArrayList<Gist> starredGists;
+
+    private ArrayList<Gist> unstarredGists;
 
     /**
      * Create an intent to show a single gist
@@ -124,6 +133,9 @@ public class GistsViewActivity extends PagerActivity implements
             gists = new String[] { gist.getId() };
         }
 
+        starredGists = new ArrayList<Gist>();
+        unstarredGists = new ArrayList<Gist>();
+
         adapter = new GistsPagerAdapter(this, gists);
         pager.setAdapter(adapter);
         pager.setOnPageChangeListener(this);
@@ -132,11 +144,22 @@ public class GistsViewActivity extends PagerActivity implements
     }
 
     @Override
+    public void onBackPressed() {
+        Intent intent = new Intent();
+        intent.putExtra(EXTRA_STARRED_GISTS, starredGists);
+        intent.putExtra(EXTRA_UNSTARRED_GISTS, unstarredGists);
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
         case android.R.id.home:
             Intent intent = new Intent(this, GistsActivity.class);
             intent.addFlags(FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_SINGLE_TOP);
+            intent.putExtra(EXTRA_STARRED_GISTS, starredGists);
+            intent.putExtra(EXTRA_UNSTARRED_GISTS, unstarredGists);
             startActivity(intent);
             return true;
         case id.m_delete:
@@ -207,5 +230,19 @@ public class GistsViewActivity extends PagerActivity implements
     public void loaded(Gist gist) {
         if (gists[pager.getCurrentItem()].equals(gist.getId()))
             updateActionBar(gist, gist.getId());
+    }
+
+    @Override
+    public void onGistStarred(Gist gist) {
+        if (unstarredGists.contains(gist))
+            unstarredGists.remove(gist);
+        starredGists.add(gist);
+    }
+
+    @Override
+    public void onGistUnstarred(Gist gist) {
+        if (starredGists.contains(gist))
+            starredGists.remove(gist);
+        unstarredGists.add(gist);
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/gist/GistsViewActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/GistsViewActivity.java
@@ -234,15 +234,23 @@ public class GistsViewActivity extends PagerActivity implements
 
     @Override
     public void onGistStarred(Gist gist) {
-        if (unstarredGists.contains(gist))
-            unstarredGists.remove(gist);
+        for (int i = 0; i < unstarredGists.size(); i++) {
+            if (unstarredGists.get(i).getId().equals(gist.getId())) {
+                unstarredGists.remove(i);
+                break;
+            }
+        }
         starredGists.add(gist);
     }
 
     @Override
     public void onGistUnstarred(Gist gist) {
-        if (starredGists.contains(gist))
-            starredGists.remove(gist);
+        for (int i = 0; i < starredGists.size(); i++) {
+            if (starredGists.get(i).getId().equals(gist.getId())) {
+                starredGists.remove(i);
+                break;
+            }
+        }
         unstarredGists.add(gist);
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/gist/MyGistsFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/MyGistsFragment.java
@@ -38,9 +38,24 @@ public class MyGistsFragment extends GistsFragment {
     private Provider<GitHubAccount> accountProvider;
 
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    public void onActivityResult(int requestCode, int resultCode,
+            Intent data) {
         if ((requestCode == GIST_CREATE || requestCode == GIST_VIEW)
                 && RESULT_OK == resultCode) {
+            if (data != null) {
+                // If we deleted a gist, we want to not display that gist
+                String id = data.getStringExtra(DeleteGistTask
+                    .EXTRA_DELETED_GIST);
+                for (int i = 0; i < items.size(); i++) {
+                    if (items.get(i).getId().equals(id)) {
+                        items.remove(i);
+                        break;
+                    }
+                }
+                getListAdapter().getWrappedAdapter().setItems(items);
+            }
+
+            // In any case, we want to refresh to get the most recent info
             forceRefresh();
             return;
         }

--- a/app/src/main/java/com/github/mobile/ui/gist/StarredGistsFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/StarredGistsFragment.java
@@ -15,8 +15,12 @@
  */
 package com.github.mobile.ui.gist;
 
+import android.os.Bundle;
+
 import com.github.mobile.core.ResourcePager;
 import com.github.mobile.core.gist.GistPager;
+
+import java.util.List;
 
 import org.eclipse.egit.github.core.Gist;
 import org.eclipse.egit.github.core.client.PageIterator;
@@ -27,6 +31,26 @@ import org.eclipse.egit.github.core.client.PageIterator;
 public class StarredGistsFragment extends GistsFragment {
 
     @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Stop gap to auto-refresh as necessary.
+        // TODO: implement logic so that only starred gists are shown
+        if (gistStarUpdater.getStarredGists().size() != 0 ||
+            gistStarUpdater.getUnstarredGists().size() != 0) {
+            mergeLocalChanges(gistStarUpdater.getStarredGists(),
+                gistStarUpdater.getUnstarredGists());
+            getListAdapter().getWrappedAdapter().setItems(items);
+            gistStarUpdater.clearStarsCache();
+            forceRefresh();
+        }
+    }
+
+    @Override
     protected ResourcePager<Gist> createPager() {
         return new GistPager(store) {
 
@@ -35,5 +59,61 @@ public class StarredGistsFragment extends GistsFragment {
                 return service.pageStarredGists(page, size);
             }
         };
+    }
+
+    private void mergeLocalChanges(List<Gist> starredGists, List<Gist>
+        unstarredGists) {
+        int starredPos = 0;
+        int unstarredPos = 0;
+        int itemsPos = 0;
+
+        while (itemsPos < items.size() && !(starredPos < starredGists.size() &&
+            unstarredPos < unstarredGists.size())) {
+            Gist curStar = null, curUnstar = null, curItem;
+            if(starredPos < starredGists.size())
+                curStar = starredGists.get(starredPos);
+            if(unstarredPos < unstarredGists.size())
+                curUnstar = unstarredGists.get(unstarredPos);
+            curItem = items.get(itemsPos);
+
+            // If this is a duplicate, just carry on
+            if (curStar != null && curStar.getId().equals(curItem.getId())) {
+                starredPos++;
+                continue;
+            }
+
+            // If this is earlier than the current spot in the list, add it
+            if (curStar != null && curStar.getCreatedAt().getTime() >=
+                curItem.getCreatedAt().getTime()) {
+                items.add(itemsPos, starredGists.get(starredPos));
+                itemsPos++;
+                starredPos++;
+                continue;
+            }
+
+            // If this is on the list but has been unstarred, remove it
+            if (curUnstar != null && curUnstar.getId().equals(curItem.getId())) {
+                items.remove(itemsPos);
+                unstarredPos++;
+                continue;
+            }
+
+            itemsPos++;
+
+            // If the unstarred list is lagging behind the items list then we
+            // want to advance the unstarred list up to the items list
+            if (curUnstar != null && curItem.getCreatedAt().getTime() <
+                curUnstar.getCreatedAt().getTime()) {
+                while (unstarredPos < unstarredGists.size()) {
+                    curUnstar = unstarredGists.get(unstarredPos);
+                    // We want to advance the unstarred location up to the
+                    // first one ahead of the items list
+                    if (curItem.getCreatedAt().getTime() <
+                        curUnstar.getCreatedAt().getTime())
+                        break;
+                    unstarredPos++;
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/github/mobile/ui/gist/StarredGistsFragment.java
+++ b/app/src/main/java/com/github/mobile/ui/gist/StarredGistsFragment.java
@@ -15,8 +15,6 @@
  */
 package com.github.mobile.ui.gist;
 
-import android.os.Bundle;
-
 import com.github.mobile.core.ResourcePager;
 import com.github.mobile.core.gist.GistPager;
 
@@ -31,15 +29,9 @@ import org.eclipse.egit.github.core.client.PageIterator;
 public class StarredGistsFragment extends GistsFragment {
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
-        // Stop gap to auto-refresh as necessary.
-        // TODO: implement logic so that only starred gists are shown
+
         if (gistStarUpdater.getStarredGists().size() != 0 ||
             gistStarUpdater.getUnstarredGists().size() != 0) {
             mergeLocalChanges(gistStarUpdater.getStarredGists(),


### PR DESCRIPTION
There were a few small issues that were bugging me about Gists, so I cleaned up a bunch of them.  Among the things that are fixed here are:

Gist options menu wasn't being updated properly
Enable/Disable wrapping did a weird sort of flickering thing
Allow gists to be created from any type of text (I'm not sure if this was a wise idea, but it seems like gists should be able to be created from any text)
Added toasts to tell the user that his or her request to star/unstar a gist was succesful
Made it so that when a user deletes a gist and/or stars a gist then that is immediately reflected in the UI.