### PR TITLE
Limit hostname when matching URL for a GitHub user

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/UrlLauncher.java
+++ b/app/src/main/java/com/github/mobile/ui/UrlLauncher.java
@@ -131,9 +131,9 @@ public class UrlLauncher {
         if (data == null)
             return null;
 
-        if (TextUtils.isEmpty(data.getHost())
+        String host = data.getHost();
+        if (TextUtils.isEmpty(host)
                 || TextUtils.isEmpty(data.getScheme())) {
-            String host = data.getHost();
             if (TextUtils.isEmpty(host))
                 host = HOST_DEFAULT;
             String scheme = data.getScheme();
@@ -149,7 +149,6 @@ public class UrlLauncher {
                     data = Uri.parse(prefix + '/' + path);
             else
                 data = Uri.parse(prefix);
-            intent.setData(data);
         }
 
         String uri = data.toString();
@@ -166,7 +165,7 @@ public class UrlLauncher {
             return createCommitIntent(uri, match);
 
         String login = userMatcher.getLogin(uri);
-        if (isValidLogin(login))
+        if (HOST_DEFAULT.equalsIgnoreCase(host) && isValidLogin(login))
             return createUserIntent(login);
 
         return null;

--- a/app/src/main/java/com/github/mobile/ui/UrlLauncher.java
+++ b/app/src/main/java/com/github/mobile/ui/UrlLauncher.java
@@ -149,6 +149,7 @@ public class UrlLauncher {
                     data = Uri.parse(prefix + '/' + path);
             else
                 data = Uri.parse(prefix);
+            intent.setData(data);
         }
 
         String uri = data.toString();


### PR DESCRIPTION
I noticed that some of the URLs, e.g. <http://magazine.rubyist.net/?0045>, in Issues can not be viewed as expected because the App thinks they are links to GitHub users.

In the diff below, hostname in URL is limited to HOST_DEFAULT, i.e. github.com, to solve this problem. This might harm using the app on GHE but I don't know if the App can be used on repositories on othere than github.com.
