### PR TITLE
[german translation] "Favorit" renamed to "Hervorhebung" to match star

### DIFF
--- a/app/res/values-de/strings.xml
+++ b/app/res/values-de/strings.xml
@@ -43,9 +43,9 @@
     <string name="error_following_person">Folgen fehlgeschlagen</string>
     <string name="error_unfollowing_person">Entfolgen fehlgeschlagen</string>
     <string name="error_checking_following_status">Prüfen des Folgestatus fehlgeschlagen</string>
-    <string name="error_starring_repository">Favorisieren fehlgeschlagen</string>
-    <string name="error_unstarring_repository">Entfernen des Favoriten fehlgeschlagen</string>
-    <string name="error_checking_starring_status">Prüfen des Favoritenstatus fehlgeschlagen</string>
+    <string name="error_starring_repository">Hervorheben fehlgeschlagen</string>
+    <string name="error_unstarring_repository">Entfernen der Hervorhebung fehlgeschlagen</string>
+    <string name="error_checking_starring_status">Prüfen des Hervorhebungsstatus fehlgeschlagen</string>
     <string name="error_rendering_markdown">Rendern der Markdown-Vorschau fehlgeschlagen</string>
     <string name="error_users_search">Suche nach Usern fehlgeschlagen</string>
     <!--  -->
@@ -141,8 +141,8 @@
     <string name="gist_description_hint">erstellt mit Android</string>
     <string name="title">Titel</string>
     <string name="edit">Bearbeiten</string>
-    <string name="starring_gist">Füge Gist als Favorit hinzu…</string>
-    <string name="unstarring_gist">Entferne favorisierten Gist…</string>
+    <string name="starring_gist">Füge Gist als Hervorhebung hinzu…</string>
+    <string name="unstarring_gist">Entferne hervorgehobenen Gist…</string>
     <string name="accounts_label">Konten</string>
     <string name="select_assignee">Verantwortlichen wählen</string>
     <string name="select_milestone">Meilenstein wählen</string>
@@ -186,8 +186,8 @@
     <string name="following_self">Ich folge</string>
     <string name="follow">Folgen</string>
     <string name="unfollow">Entfolgen</string>
-    <string name="star">Favorisieren</string>
-    <string name="unstar">Favorit entfernen</string>
+    <string name="star">Hervorheben</string>
+    <string name="unstar">Hervorhebung entfernen</string>
     <string name="members">Mitglieder</string>
     <string name="closing_issue">Schließe Problem…</string>
     <string name="reopening_issue">Problem neu öffnen…</string>
@@ -235,8 +235,8 @@
     <string name="code">Code</string>
     <string name="following_user">Folgen…</string>
     <string name="unfollowing_user">Entfolgen…</string>
-    <string name="starring_repository">Favorisieren…</string>
-    <string name="unstarring_repository">Favorit entfernen…</string>
+    <string name="starring_repository">Hervorheben…</string>
+    <string name="unstarring_repository">Hervorhebung entfernen…</string>
     <string name="navigate_to">Navigiere zu…</string>
     <string name="navigate_to_user">Navigiere zu %s</string>
     <string name="contributions">%d Commits</string>


### PR DESCRIPTION
I am not sure if "Hervorhebung" is a better german word for "star". Perhaps not needed if github/android#544 is implemented. Another option would be to use no translation, as the website is not translated either.