### PR TITLE
Add Browsable category to intent-filter

### DIFF
--- a/app/AndroidManifest.xml
+++ b/app/AndroidManifest.xml
@@ -251,39 +251,39 @@
             android:excludeFromRecents="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<category android:name="android.intent.category.DEFAULT" />
 
                 <data
                     android:host="github.com"
                     android:scheme="http" />
-
-                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<category android:name="android.intent.category.DEFAULT" />
 
                 <data
                     android:host="github.com"
                     android:scheme="https" />
-
-                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<category android:name="android.intent.category.DEFAULT" />
 
                 <data
                     android:host="gist.github.com"
                     android:scheme="http" />
-
-                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+				<category android:name="android.intent.category.BROWSABLE" />
+				<category android:name="android.intent.category.DEFAULT" />
 
                 <data
                     android:host="gist.github.com"
                     android:scheme="https" />
-
-                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
CATEGORY_BROWSABLE - The target activity allows itself to be started by a web browser to display data referenced by a link—such as an image or an e-mail message. Stated here: http://developer.android.com/guide/components/intents-filters.html