### PR TITLE
Upgraded to Android Gradle Plugin 1.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
http://jcenter.bintray.com/com/android/tools/build/gradle/
http://tools.android.com/tech-docs/new-build-system

Release notes:

1.1.2 (2015/02/26)

    Path is normalized when creating mockable jar for unit testing.
    Fixed an issue where "archivesBaseName" setting in build.gradle was ignored.
    Unresolved placeholder failure in manifest merger when building library test application.

1.1.1 (2015/02/24)

    Only variants that package a Wear app will now trigger building them.
    Dependency related issues now fail at build time rather than at debug time. This is to allow running diagnostic tasks (such as 'dependencies') to help resolve the conflict.
    Calling android.getBootClasspath() is now possible again.

1.1.0 (2015/02/17)

    Unit testing support. Unit testing code is run on the local JVM, against a special version of android.jar that is compatible with popular mocking frameworks (e.g. Mockito).
        New tasks: test, testDebug/testRelease, testMyFlavorDebug (when using flavors).
        New source folders recognized as unit tests:
        src/test/java, src/testDebug/java, src/testMyFlavor/java etc.
        New configurations for adding test-only dependencies, e.g.
        testCompile 'junit:junit:4.11'
        testMyFlavorCompile 'some:library:1.0'
        Not compatible with Jack at the moment.
        New option, android.testOptions.unitTests.returnDefaultValues to control the behaviour of the "mockable" android.jar.
    Task names that used to contain 'Test', e.g. 'assembleDebugTest' now use 'AndroidTest', e.g. 'assembleDebugAndroidTest'. This is to distinguish them from the unit test tasks, e.g. 'assembleDebugUnitTest'.
    ProGuard configuration files are no longer applied to the test APK. If minification is enabled, the test APK will be processed by ProGuard only to apply the mapping file generated when minifying the main APK.
    Fixes and changes to the dependency management:
        Properly handle 'provided' and 'package' scopes to do what they should be doing.
        'provided' and 'package' cannot be used with Android Libraries, and will generate an error
        sync tested and test dependency trees:
            if the same version of an artifact is present in both, it'll get skipped in the test app.
            if the version is different it'll generate a build error. Gradle provides mechanism to resolve this.
    Added support for anyDpi resource qualifier in the resource merger.
    Projects with large number of Android Modules will see evaluation and IDE sync speed improvements (YMMV)


1.0.1 (2014/1/9)

    Fix 81638 : Fix PermGen issue when running extractAnnotations.
    Fix small manifest merger issues when importing libraries with targetSdkVersion < 16
    Fix density ordering when running with JDK8.
    Fix 82662 : Disable passing --no-optimize to dx.