### PR TITLE
Make tests stable on api level 21 and fix some typo

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/MainActivity.java
+++ b/app/src/main/java/com/github/mobile/ui/MainActivity.java
@@ -145,30 +145,30 @@ public class MainActivity extends BaseActivity implements NavigationDrawerFragme
     public void onNavigationDrawerItemSelected(int position) {
         if (navigationAdapter.getItem(position).getType() == TYPE_SEPERATOR)
             return;
-        Fragment fragmet;
+        Fragment fragment;
         Bundle args = new Bundle();
         switch (position) {
             case 1:
-                fragmet = new HomePagerFragment();
+                fragment = new HomePagerFragment();
                 args.putSerializable("org", org);
                 break;
             case 2:
-                fragmet = new GistsPagerFragment();
+                fragment = new GistsPagerFragment();
                 break;
             case 3:
-                fragmet = new IssueDashboardPagerFragment();
+                fragment = new IssueDashboardPagerFragment();
                 break;
             case 4:
-                fragmet = new FilterListFragment();
+                fragment = new FilterListFragment();
                 break;
             default:
-                fragmet = new HomePagerFragment();
+                fragment = new HomePagerFragment();
                 args.putSerializable("org", orgs.get(position - 6));
                 break;
         }
-        fragmet.setArguments(args);
+        fragment.setArguments(args);
         FragmentManager manager = getSupportFragmentManager();
-        manager.beginTransaction().replace(R.id.container, fragmet).commit();
+        manager.beginTransaction().replace(R.id.container, fragment).commit();
     }
 
 }

--- a/integration-tests/src/main/java/com/github/mobile/tests/ActivityTest.java
+++ b/integration-tests/src/main/java/com/github/mobile/tests/ActivityTest.java
@@ -96,6 +96,8 @@ public abstract class ActivityTest<T extends Activity> extends
      * @param text
      */
     protected void send(final String text) {
+        getInstrumentation().waitForIdleSync();
         getInstrumentation().sendStringSync(text);
+        getInstrumentation().waitForIdleSync();
     }
 }

--- a/integration-tests/src/main/java/com/github/mobile/tests/gist/CreateCommentActivityTest.java
+++ b/integration-tests/src/main/java/com/github/mobile/tests/gist/CreateCommentActivityTest.java
@@ -52,7 +52,7 @@ public class CreateCommentActivityTest extends
      *
      * @throws Throwable
      */
-    public void testEmptyCommentIsProhitibed() throws Throwable {
+    public void testEmptyCommentIsProhibited() throws Throwable {
         View createMenu = view(id.m_apply);
         assertFalse(createMenu.isEnabled());
         final EditText comment = editText(id.et_comment);


### PR DESCRIPTION
```
getInstrumentation().sendStringSync(text);
```
On api level 21, the tests are not stable, that's because after call `sendStringSync("xxx")`, you can't get stable value from `editText.getText()`, according to the official functional test sample, call `waitForIdleSync()` around `sendStringSync()` can fix this.