### PR TITLE
Fixing lint error "SuspiciousImport: 'import android.R' statement"

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/SlidingTabStrip.java
+++ b/app/src/main/java/com/github/mobile/ui/SlidingTabStrip.java
@@ -16,7 +16,6 @@
 
 package com.github.mobile.ui;
 
-import android.R;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -65,7 +64,7 @@ class SlidingTabStrip extends LinearLayout {
         final float density = getResources().getDisplayMetrics().density;
 
         TypedValue outValue = new TypedValue();
-        context.getTheme().resolveAttribute(R.attr.colorForeground, outValue, true);
+        context.getTheme().resolveAttribute(android.R.attr.colorForeground, outValue, true);
         final int themeForegroundColor =  outValue.data;
 
         mDefaultBottomBorderColor = setColorAlpha(themeForegroundColor,


### PR DESCRIPTION
 ../../src/main/java/com/github/mobile/ui/SlidingTabStrip.java:19: Don't include android.R here; use a fully qualified name for each usage instead
```java
  16 
  17 package com.github.mobile.ui;
  18 
  19 import android.R;
  20 import android.content.Context;
  21 import android.graphics.Canvas;
```
Priority: 9 / 10
Category: Correctness
Severity: Warning
Explanation: 'import android.R' statement.
Importing android.R is usually not intentional; it sometimes happens when you use an IDE and ask it to automatically add imports at a time when your project's R class it not present.

Once the import is there you might get a lot of "confusing" error messages because of course the fields available on android.R are not the ones you'd expect from just looking at your own R class. 