### PR TITLE
Add unit test framework

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,4 +61,9 @@ dependencies {
     compile 'com.afollestad:material-dialogs:0.6.3.1'
     //Self compiled .aar version of wishlist
     compile (name:'lib', ext:'aar')
+    testCompile 'junit:junit:4.12'
+    testCompile('org.robolectric:robolectric:3.0-rc2') {
+        exclude group: 'commons-logging', module: 'commons-logging'
+        exclude group: 'org.apache.httpcomponents', module: 'httpclient'
+    }
 }


### PR DESCRIPTION
Fix #733 
For more reference, https://www.bignerdranch.com/blog/triumph-android-studio-1-2-sneaks-in-full-testing-support/

So, as of AS1.2+ unit test is natively supported.