### PR TITLE
fixing lint: LongLogTag

### DIFF
--- a/app/src/main/java/com/github/mobile/accounts/AccountAuthenticator.java
+++ b/app/src/main/java/com/github/mobile/accounts/AccountAuthenticator.java
@@ -48,7 +48,7 @@ import org.eclipse.egit.github.core.service.OAuthService;
 
 public class AccountAuthenticator extends AbstractAccountAuthenticator {
 
-    private static final String TAG = "GitHubAccountAuthenticator";
+    private static final String TAG = "GHAccountAuthenticator";
 
     private static final List<String> SCOPES = Arrays.asList("repo", "user", "gist");
 


### PR DESCRIPTION
LongLogTag: Too Long Log Tags
---
```../../src/main/java/com/github/mobile/accounts/AccountAuthenticator.java:151```: The logging tag can be at most 23 characters, was 26 (GitHubAccountAuthenticator)
```java
 148     public Bundle getAuthToken(final AccountAuthenticatorResponse response,
 149             final Account account, final String authTokenType,
 150             final Bundle options) throws NetworkErrorException {
 151         Log.d(TAG, "Retrieving OAuth2 token");
 152 
 153         final Bundle bundle = new Bundle();
```
```../../src/main/java/com/github/mobile/accounts/AccountAuthenticator.java:175```: The logging tag can be at most 23 characters, was 26 (GitHubAccountAuthenticator)
```java
 172             if (TextUtils.isEmpty(authToken))
 173                 authToken = createAuthorization(service);
 174         } catch (IOException e) {
 175             Log.e(TAG, "Authorization retrieval failed", e);
 176             throw new NetworkErrorException(e);
 177         }
```
Priority: 5 / 10
Category: Correctness
Severity: Error
Explanation: Too Long Log Tags.
Log tags are only allowed to be at most 23 tag characters long. 