### PR TITLE
Fix broken build gradle as a consequence of missing material dialogs deps 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile 'com.squareup.okio:okio:1.1.0'
     compile 'com.squareup.okhttp:okhttp:2.2.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
-    compile 'com.afollestad:material-dialogs:0.7.2.7'
+    compile 'com.afollestad:material-dialogs:0.7.3.2'
     //Self compiled .aar version of wishlist
     compile (name:'lib', ext:'aar')
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Maven artifact for Material Dialogs has changed version, the version referenced in build.grade was not available anymore and because of it the build was broken. I have updated the version to be in sync with the one in the maven repository