### PR TITLE
Temp fix for weird AppBarLayout bug

### DIFF
--- a/app/src/main/java/com/github/mobile/ui/PatchedScrollingViewBehavior.java
+++ b/app/src/main/java/com/github/mobile/ui/PatchedScrollingViewBehavior.java
@@ -1,0 +1,59 @@
+package com.github.mobile.ui;
+
+import android.content.Context;
+import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.v4.view.ViewCompat;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+
+import java.util.List;
+
+public class PatchedScrollingViewBehavior extends AppBarLayout.ScrollingViewBehavior {
+
+    public PatchedScrollingViewBehavior() {
+        super();
+    }
+
+    public PatchedScrollingViewBehavior(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean onMeasureChild(CoordinatorLayout parent, View child, int parentWidthMeasureSpec, int widthUsed, int parentHeightMeasureSpec, int heightUsed) {
+        if(child.getLayoutParams().height == -1) {
+            List<View> dependencies = parent.getDependencies(child);
+            if(dependencies.isEmpty())
+                return false;
+
+            AppBarLayout appBar = findFirstAppBarLayout(dependencies);
+            if(appBar != null && ViewCompat.isLaidOut(appBar)) {
+                if(ViewCompat.getFitsSystemWindows(appBar))
+                    ViewCompat.setFitsSystemWindows(child, true);
+
+                int parentHeight = View.MeasureSpec.getSize(parentHeightMeasureSpec);
+                int height = parentHeight - appBar.getMeasuredHeight();
+                int heightMeasureSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
+                parent.onMeasureChild(child, parentWidthMeasureSpec, widthUsed, heightMeasureSpec, heightUsed);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    private static AppBarLayout findFirstAppBarLayout(List<View> views) {
+        int i = 0;
+
+        for(int z = views.size(); i < z; ++i) {
+            View view = views.get(i);
+            if(view instanceof AppBarLayout) {
+                return (AppBarLayout)view;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/src/main/res/layout/pager_with_tabs.xml
+++ b/app/src/main/res/layout/pager_with_tabs.xml
@@ -49,8 +49,7 @@
 
     <com.github.mobile.ui.ViewPager
         android:id="@+id/vp_pages"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior"
-        android:layout_below="@id/sliding_tabs_layout"
+        app:layout_behavior="com.github.mobile.ui.PatchedScrollingViewBehavior"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 


### PR DESCRIPTION
This is the bug https://code.google.com/p/android/issues/detail?id=176373, our workaround will be a bit worse but there seems to be a bug with AppBarLayout.getTotalScrollRange() so I had to remove it for the moment. 

When the bugs are fixed we can remove this, until then it will aleast work correctly